### PR TITLE
CWH-39: Add snapshot deletion actions to Action Center

### DIFF
--- a/backend/app/api/v1/actions.py
+++ b/backend/app/api/v1/actions.py
@@ -11,7 +11,7 @@ Business logic is delegated to the service layer.
 """
 
 import structlog
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
@@ -20,11 +20,54 @@ from app.models.action_models import (
     BatchApprovalRequest,
     BatchRejectRequest,
 )
-from app.services.action_service import action_service
+from app.services.action_service import SafetyCheckFailedError, action_service
+from app.services.detection_service import detection_service
 
 logger = structlog.get_logger()
 
 router = APIRouter()
+
+
+# =============================================================================
+# LIST ROUTE
+# =============================================================================
+
+
+@router.get("/")
+async def list_actions(
+    status: str | None = Query(default=None),
+    resource_type: str | None = Query(default=None),
+    limit: int = Query(default=100, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    List detections/actions with optional filters.
+
+    Args:
+        status: Filter by status (pending, approved, executed, rejected, failed)
+        resource_type: Filter by resource type (ec2_instance, ebs_volume, ebs_snapshot)
+        limit: Page size (max 100)
+        offset: Pagination offset
+
+    Returns:
+        Paginated list of detections
+    """
+    try:
+        result = await detection_service.list_detections(
+            db=db,
+            status=status,
+            resource_type=resource_type,
+            limit=limit,
+            offset=offset,
+        )
+    except Exception as e:
+        logger.exception("List actions failed", error=str(e), exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to list actions: {e!s}",
+        ) from e
+    return result
 
 
 # =============================================================================
@@ -231,6 +274,8 @@ async def approve_detection(
             approved_by=request.approved_by,
             dry_run=request.dry_run,
         )
+    except SafetyCheckFailedError as e:
+        raise HTTPException(status_code=409, detail=str(e)) from e
     except ValueError as e:
         # Business logic errors (not found, invalid status, etc.)
         status_code = 404 if "not found" in str(e).lower() else 400

--- a/backend/app/aws/snapshot_client.py
+++ b/backend/app/aws/snapshot_client.py
@@ -1,0 +1,119 @@
+"""
+Snapshot-specific AWS client operations
+
+Thin wrapper around boto3 for snapshot-related EC2 API calls.
+"""
+
+from datetime import UTC, datetime
+
+import structlog
+from botocore.exceptions import ClientError
+
+from app.aws.client import AWSClientFactory
+
+logger = structlog.get_logger()
+
+
+class SnapshotNotFoundError(Exception):
+    """Raised when a snapshot does not exist in AWS"""
+
+
+class SnapshotClient:
+    """Thin wrapper for snapshot-specific EC2 API calls"""
+
+    def __init__(self, client_factory: AWSClientFactory):
+        self.ec2_client = client_factory.get_ec2_client()
+
+    def describe_snapshot(self, snapshot_id: str) -> dict:
+        """
+        Describe a snapshot and return its metadata.
+
+        Args:
+            snapshot_id: EBS snapshot ID
+
+        Returns:
+            dict with snapshot_id, size_gb, start_time, age_days, state
+
+        Raises:
+            SnapshotNotFoundError: if the snapshot no longer exists
+        """
+        try:
+            response = self.ec2_client.describe_snapshots(SnapshotIds=[snapshot_id])
+        except ClientError as e:
+            error_code = e.response["Error"]["Code"]
+            if error_code in ("InvalidSnapshot.NotFound", "InvalidSnapshotID.NotFound"):
+                raise SnapshotNotFoundError(
+                    f"Snapshot {snapshot_id} not found"
+                ) from e
+            raise
+
+        snapshots = response.get("Snapshots", [])
+        if not snapshots:
+            raise SnapshotNotFoundError(f"Snapshot {snapshot_id} not found")
+
+        snapshot = snapshots[0]
+        start_time = snapshot["StartTime"]
+        now = datetime.now(UTC)
+        if start_time.tzinfo is None:
+            start_time = start_time.replace(tzinfo=UTC)
+        age_days = (now - start_time).days
+
+        logger.info(
+            "Described snapshot",
+            snapshot_id=snapshot_id,
+            age_days=age_days,
+            size_gb=snapshot["VolumeSize"],
+        )
+
+        return {
+            "snapshot_id": snapshot["SnapshotId"],
+            "size_gb": snapshot["VolumeSize"],
+            "start_time": start_time.isoformat(),
+            "age_days": age_days,
+            "state": snapshot["State"],
+        }
+
+    def check_snapshot_ami_links(self, snapshot_id: str) -> list[str]:
+        """
+        Return the IDs of any active AMIs that reference this snapshot.
+
+        Uses the block-device-mapping.snapshot-id filter so only AMIs
+        that directly use this snapshot are returned.
+
+        Args:
+            snapshot_id: EBS snapshot ID
+
+        Returns:
+            List of AMI IDs in 'available' state that reference this snapshot
+        """
+        try:
+            response = self.ec2_client.describe_images(
+                Filters=[
+                    {
+                        "Name": "block-device-mapping.snapshot-id",
+                        "Values": [snapshot_id],
+                    }
+                ]
+            )
+        except Exception as e:
+            logger.warning(
+                "Error checking AMI links for snapshot",
+                snapshot_id=snapshot_id,
+                error=str(e),
+            )
+            return []
+
+        ami_ids = [
+            image["ImageId"]
+            for image in response.get("Images", [])
+            if image.get("State") == "available"
+        ]
+
+        if ami_ids:
+            logger.warning(
+                "Snapshot is linked to active AMIs",
+                snapshot_id=snapshot_id,
+                ami_ids=ami_ids,
+            )
+
+        return ami_ids

--- a/backend/app/models/detection_models.py
+++ b/backend/app/models/detection_models.py
@@ -116,11 +116,24 @@ class ScanResponse(BaseModel):
         }
 
 
+class SnapshotMetadata(BaseModel):
+    """Optional snapshot-specific metadata enriched from live AWS data"""
+
+    snapshot_age_days: int | None = None
+    snapshot_size_gb: float | None = None
+    linked_ami_id: str | None = None
+    blocked_reason: str | None = None
+
+
 class DetectionDetailResponse(BaseModel):
     """Response model for detection detail with preview"""
 
     detection: DetectionResponse
     action_preview: dict[str, Any]
+    # Snapshot-specific fields (populated from live AWS data when resource_type == ebs_snapshot)
+    snapshot_age_days: int | None = None
+    snapshot_size_gb: float | None = None
+    linked_ami_id: str | None = None
 
     class Config:
         json_schema_extra: ClassVar[dict[str, Any]] = {
@@ -133,5 +146,8 @@ class DetectionDetailResponse(BaseModel):
                     "can_rollback": True,
                     "rollback_window_days": 7,
                 },
+                "snapshot_age_days": None,
+                "snapshot_size_gb": None,
+                "linked_ami_id": None,
             }
         }

--- a/backend/app/safety/dry_run.py
+++ b/backend/app/safety/dry_run.py
@@ -84,14 +84,37 @@ class DryRunExecutor:
         """
         Preview deleting an EBS snapshot
 
+        snapshot_data may contain live-enriched fields from SnapshotClient:
+          - snapshot_age_days: int
+          - snapshot_size_gb: float
+          - linked_ami_ids: list[str]
+
         Returns:
-            Preview result with impact analysis
+            Structured preview result including metadata and blocked_reason
         """
+        linked_ami_ids: list[str] = snapshot_data.get("linked_ami_ids", [])
+        blocked_reason: str | None = None
+        if linked_ami_ids:
+            blocked_reason = (
+                f"Snapshot is linked to active AMI(s): {', '.join(linked_ami_ids)}. "
+                "Deregister the AMI(s) before deleting this snapshot."
+            )
+
+        size_gb = snapshot_data.get("snapshot_size_gb") or snapshot_data.get(
+            "size_gb", 0
+        )
+
         return {
             "action": "delete_ebs_snapshot",
             "resource_id": snapshot_id,
             "resource_type": "ebs_snapshot",
             "dry_run": True,
+            "snapshot_age_days": snapshot_data.get("snapshot_age_days"),
+            "snapshot_size_gb": size_gb,
+            "linked_ami_id": linked_ami_ids[0] if linked_ami_ids else None,
+            "linked_ami_ids": linked_ami_ids,
+            "blocked_reason": blocked_reason,
+            "would_delete": not bool(linked_ami_ids),
             "impact": {
                 "snapshot_will_be": "permanently deleted",
                 "data_preserved": False,
@@ -99,7 +122,7 @@ class DryRunExecutor:
                 "estimated_savings_inr": snapshot_data.get(
                     "estimated_monthly_savings_inr", 0
                 ),
-                "size_gb": snapshot_data.get("size_gb", 0),
+                "size_gb": size_gb,
             },
             "risks": [
                 "PERMANENT data loss - snapshot cannot be recovered",

--- a/backend/app/services/action_service.py
+++ b/backend/app/services/action_service.py
@@ -8,6 +8,7 @@ import structlog
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.aws.client import AWSClientFactory
+from app.aws.snapshot_client import SnapshotClient
 from app.repositories.audit_repository import audit_repository
 from app.repositories.detection_repository import detection_repository
 from app.safety.dry_run import DryRunExecutor
@@ -16,6 +17,10 @@ from app.schemas.audit import ActionType, AuditLog, AuditStatus
 from app.schemas.detection import Detection, DetectionStatus, ResourceType
 
 logger = structlog.get_logger()
+
+
+class SafetyCheckFailedError(Exception):
+    """Raised when a pre-execution safety check fails (e.g. snapshot linked to active AMI)"""
 
 
 class ActionService:
@@ -33,6 +38,7 @@ class ActionService:
         self,
         db: AsyncSession,
         detection_id: int,
+        client_factory: AWSClientFactory | None = None,
     ) -> dict:
         """
         Preview action impact (dry-run)
@@ -40,6 +46,7 @@ class ActionService:
         Args:
             db: Database session
             detection_id: Detection ID
+            client_factory: Optional AWS client factory (used to enrich snapshot previews)
 
         Returns:
             Preview result with impact analysis
@@ -59,6 +66,25 @@ class ActionService:
         elif detection.resource_type.value == "ebs_volume":
             preview = dry_run.preview_ebs_delete(detection.resource_id, detection_dict)
         elif detection.resource_type.value == "ebs_snapshot":
+            # Enrich with live AWS snapshot metadata before preview
+            if client_factory is None:
+                client_factory = AWSClientFactory()
+            snapshot_client = SnapshotClient(client_factory)
+            try:
+                snapshot_meta = snapshot_client.describe_snapshot(detection.resource_id)
+                ami_links = snapshot_client.check_snapshot_ami_links(
+                    detection.resource_id
+                )
+                detection_dict["snapshot_age_days"] = snapshot_meta["age_days"]
+                detection_dict["snapshot_size_gb"] = snapshot_meta["size_gb"]
+                detection_dict["linked_ami_ids"] = ami_links
+            except Exception as e:
+                logger.warning(
+                    "Failed to get live snapshot metadata for preview",
+                    detection_id=detection_id,
+                    resource_id=detection.resource_id,
+                    error=str(e),
+                )
             preview = dry_run.preview_snapshot_delete(
                 detection.resource_id, detection_dict
             )
@@ -118,6 +144,7 @@ class ActionService:
                 detection,
                 approved_by,
                 dry_run,
+                client_factory,
             )
 
             # STEP 4: Update detection status based on AWS result
@@ -184,12 +211,37 @@ class ActionService:
             # All changes (detection + audit_log) committed together
             return {"status": "success"}
 
+    def _live_snapshot_safety_check(
+        self,
+        snapshot_id: str,
+        client_factory: AWSClientFactory,
+    ) -> None:
+        """
+        Verify the snapshot is not linked to any active AMIs before deletion.
+
+        Args:
+            snapshot_id: EBS snapshot ID to check
+            client_factory: AWS client factory
+
+        Raises:
+            SafetyCheckFailedError: if the snapshot is still referenced by active AMIs
+        """
+        snapshot_client = SnapshotClient(client_factory)
+        ami_ids = snapshot_client.check_snapshot_ami_links(snapshot_id)
+        if ami_ids:
+            raise SafetyCheckFailedError(
+                f"Snapshot {snapshot_id} is still linked to active AMI(s): "
+                f"{', '.join(ami_ids)}. Deregister the AMI(s) before deleting "
+                "this snapshot."
+            )
+
     async def _execute_action(
         self,
         executor: SafeExecutor,
         detection: Detection,
         approved_by: str,
         dry_run: bool,
+        client_factory: AWSClientFactory | None = None,
     ) -> dict:
         """Execute action based on resource type"""
         resource_type = detection.resource_type.value
@@ -200,6 +252,9 @@ class ActionService:
         elif resource_type == "ebs_volume":
             return executor.delete_ebs_volume(resource_id, approved_by, dry_run)
         elif resource_type == "ebs_snapshot":
+            # Run live safety check before actual deletion (not on dry runs)
+            if not dry_run and client_factory is not None:
+                self._live_snapshot_safety_check(resource_id, client_factory)
             return executor.delete_snapshot(resource_id, approved_by, dry_run)
         else:
             raise ValueError(f"Unknown resource type: {resource_type}")

--- a/backend/tests/test_action_service_snapshot.py
+++ b/backend/tests/test_action_service_snapshot.py
@@ -1,0 +1,74 @@
+"""
+Unit tests for ActionService snapshot-specific behaviour
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.action_service import ActionService, SafetyCheckFailedError
+
+
+class TestLiveSnapshotSafetyCheck:
+    def test_passes_when_no_ami_links(self):
+        snapshot_client = MagicMock()
+        snapshot_client.check_snapshot_ami_links.return_value = []
+
+        service = ActionService()
+        factory = MagicMock()
+
+        with patch(
+            "app.services.action_service.SnapshotClient",
+            return_value=snapshot_client,
+        ):
+            # Should not raise
+            service._live_snapshot_safety_check("snap-free", factory)
+
+        snapshot_client.check_snapshot_ami_links.assert_called_once_with("snap-free")
+
+    def test_raises_when_ami_links_exist(self):
+        snapshot_client = MagicMock()
+        snapshot_client.check_snapshot_ami_links.return_value = ["ami-111", "ami-222"]
+
+        service = ActionService()
+        factory = MagicMock()
+
+        with patch(
+            "app.services.action_service.SnapshotClient",
+            return_value=snapshot_client,
+        ):
+            with pytest.raises(SafetyCheckFailedError) as exc_info:
+                service._live_snapshot_safety_check("snap-linked", factory)
+
+        assert "snap-linked" in str(exc_info.value)
+        assert "ami-111" in str(exc_info.value)
+
+    def test_error_message_lists_all_ami_ids(self):
+        snapshot_client = MagicMock()
+        snapshot_client.check_snapshot_ami_links.return_value = [
+            "ami-aaa",
+            "ami-bbb",
+            "ami-ccc",
+        ]
+
+        service = ActionService()
+        factory = MagicMock()
+
+        with patch(
+            "app.services.action_service.SnapshotClient",
+            return_value=snapshot_client,
+        ):
+            with pytest.raises(SafetyCheckFailedError) as exc_info:
+                service._live_snapshot_safety_check("snap-multi", factory)
+
+        error_msg = str(exc_info.value)
+        assert "ami-aaa" in error_msg
+        assert "ami-bbb" in error_msg
+        assert "ami-ccc" in error_msg
+
+
+class TestSafetyCheckFailedErrorIsException:
+    def test_is_exception_subclass(self):
+        err = SafetyCheckFailedError("test error")
+        assert isinstance(err, Exception)
+        assert str(err) == "test error"

--- a/backend/tests/test_dry_run.py
+++ b/backend/tests/test_dry_run.py
@@ -1,0 +1,86 @@
+"""
+Unit tests for DryRunExecutor snapshot preview
+"""
+
+import pytest
+
+from app.safety.dry_run import DryRunExecutor
+
+
+class TestPreviewSnapshotDelete:
+    def test_returns_structured_result(self):
+        executor = DryRunExecutor()
+        result = executor.preview_snapshot_delete(
+            "snap-abc123",
+            {
+                "estimated_monthly_savings_inr": 500.0,
+                "size_gb": 50,
+            },
+        )
+
+        assert result["action"] == "delete_ebs_snapshot"
+        assert result["resource_id"] == "snap-abc123"
+        assert result["resource_type"] == "ebs_snapshot"
+        assert result["dry_run"] is True
+        assert "impact" in result
+        assert "risks" in result
+        assert "recommendations" in result
+        assert "previewed_at" in result
+
+    def test_includes_snapshot_metadata_fields(self):
+        executor = DryRunExecutor()
+        result = executor.preview_snapshot_delete(
+            "snap-abc",
+            {
+                "snapshot_age_days": 90,
+                "snapshot_size_gb": 200.0,
+                "linked_ami_ids": [],
+            },
+        )
+
+        assert result["snapshot_age_days"] == 90
+        assert result["snapshot_size_gb"] == 200.0
+        assert result["linked_ami_id"] is None
+        assert result["blocked_reason"] is None
+        assert result["would_delete"] is True
+
+    def test_sets_blocked_reason_when_ami_links_exist(self):
+        executor = DryRunExecutor()
+        result = executor.preview_snapshot_delete(
+            "snap-linked",
+            {
+                "linked_ami_ids": ["ami-111", "ami-222"],
+            },
+        )
+
+        assert result["linked_ami_id"] == "ami-111"
+        assert result["linked_ami_ids"] == ["ami-111", "ami-222"]
+        assert result["blocked_reason"] is not None
+        assert "ami-111" in result["blocked_reason"]
+        assert result["would_delete"] is False
+
+    def test_no_blocked_reason_when_no_ami_links(self):
+        executor = DryRunExecutor()
+        result = executor.preview_snapshot_delete(
+            "snap-free",
+            {"linked_ami_ids": []},
+        )
+
+        assert result["blocked_reason"] is None
+        assert result["linked_ami_id"] is None
+        assert result["would_delete"] is True
+
+    def test_size_gb_falls_back_to_size_gb_key(self):
+        executor = DryRunExecutor()
+        result = executor.preview_snapshot_delete(
+            "snap-xyz",
+            {"size_gb": 75},
+        )
+
+        assert result["snapshot_size_gb"] == 75
+
+    def test_no_exception_when_snapshot_data_is_empty(self):
+        executor = DryRunExecutor()
+        # Should not raise even with an empty dict
+        result = executor.preview_snapshot_delete("snap-empty", {})
+        assert result["action"] == "delete_ebs_snapshot"

--- a/backend/tests/test_snapshot_client.py
+++ b/backend/tests/test_snapshot_client.py
@@ -1,0 +1,144 @@
+"""
+Unit tests for SnapshotClient
+"""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+from app.aws.snapshot_client import SnapshotClient, SnapshotNotFoundError
+
+
+def _make_client_factory(ec2_client):
+    factory = MagicMock()
+    factory.get_ec2_client.return_value = ec2_client
+    return factory
+
+
+class TestDescribeSnapshot:
+    def test_returns_correct_shape(self):
+        ec2 = MagicMock()
+        start_time = datetime(2025, 1, 1, tzinfo=UTC)
+        ec2.describe_snapshots.return_value = {
+            "Snapshots": [
+                {
+                    "SnapshotId": "snap-abc123",
+                    "VolumeSize": 50,
+                    "StartTime": start_time,
+                    "State": "completed",
+                }
+            ]
+        }
+        client = SnapshotClient(_make_client_factory(ec2))
+        result = client.describe_snapshot("snap-abc123")
+
+        ec2.describe_snapshots.assert_called_once_with(SnapshotIds=["snap-abc123"])
+        assert result["snapshot_id"] == "snap-abc123"
+        assert result["size_gb"] == 50
+        assert result["state"] == "completed"
+        assert result["age_days"] >= 0
+
+    def test_age_days_computed_correctly(self):
+        ec2 = MagicMock()
+        # Snapshot created exactly 30 days ago
+        start_time = datetime.now(UTC) - timedelta(days=30)
+        ec2.describe_snapshots.return_value = {
+            "Snapshots": [
+                {
+                    "SnapshotId": "snap-old",
+                    "VolumeSize": 100,
+                    "StartTime": start_time,
+                    "State": "completed",
+                }
+            ]
+        }
+        client = SnapshotClient(_make_client_factory(ec2))
+        result = client.describe_snapshot("snap-old")
+
+        assert result["age_days"] == 30
+
+    def test_raises_snapshot_not_found_on_client_error(self):
+        ec2 = MagicMock()
+        ec2.describe_snapshots.side_effect = ClientError(
+            {"Error": {"Code": "InvalidSnapshot.NotFound", "Message": "not found"}},
+            "DescribeSnapshots",
+        )
+        client = SnapshotClient(_make_client_factory(ec2))
+
+        with pytest.raises(SnapshotNotFoundError):
+            client.describe_snapshot("snap-missing")
+
+    def test_raises_snapshot_not_found_when_empty_list(self):
+        ec2 = MagicMock()
+        ec2.describe_snapshots.return_value = {"Snapshots": []}
+        client = SnapshotClient(_make_client_factory(ec2))
+
+        with pytest.raises(SnapshotNotFoundError):
+            client.describe_snapshot("snap-gone")
+
+    def test_reraises_other_client_errors(self):
+        ec2 = MagicMock()
+        ec2.describe_snapshots.side_effect = ClientError(
+            {"Error": {"Code": "UnauthorizedOperation", "Message": "no perms"}},
+            "DescribeSnapshots",
+        )
+        client = SnapshotClient(_make_client_factory(ec2))
+
+        with pytest.raises(ClientError):
+            client.describe_snapshot("snap-abc")
+
+
+class TestCheckSnapshotAmiLinks:
+    def test_returns_active_ami_ids(self):
+        ec2 = MagicMock()
+        ec2.describe_images.return_value = {
+            "Images": [
+                {"ImageId": "ami-111", "State": "available"},
+                {"ImageId": "ami-222", "State": "available"},
+            ]
+        }
+        client = SnapshotClient(_make_client_factory(ec2))
+        result = client.check_snapshot_ami_links("snap-abc")
+
+        ec2.describe_images.assert_called_once_with(
+            Filters=[
+                {
+                    "Name": "block-device-mapping.snapshot-id",
+                    "Values": ["snap-abc"],
+                }
+            ]
+        )
+        assert result == ["ami-111", "ami-222"]
+
+    def test_filters_out_non_available_amis(self):
+        ec2 = MagicMock()
+        ec2.describe_images.return_value = {
+            "Images": [
+                {"ImageId": "ami-available", "State": "available"},
+                {"ImageId": "ami-deregistered", "State": "deregistered"},
+                {"ImageId": "ami-pending", "State": "pending"},
+            ]
+        }
+        client = SnapshotClient(_make_client_factory(ec2))
+        result = client.check_snapshot_ami_links("snap-abc")
+
+        assert result == ["ami-available"]
+
+    def test_returns_empty_list_when_no_amis(self):
+        ec2 = MagicMock()
+        ec2.describe_images.return_value = {"Images": []}
+        client = SnapshotClient(_make_client_factory(ec2))
+
+        result = client.check_snapshot_ami_links("snap-orphan")
+        assert result == []
+
+    def test_returns_empty_list_on_error(self):
+        ec2 = MagicMock()
+        ec2.describe_images.side_effect = Exception("Network error")
+        client = SnapshotClient(_make_client_factory(ec2))
+
+        # Should not raise, returns empty list and logs warning
+        result = client.check_snapshot_ami_links("snap-abc")
+        assert result == []

--- a/frontend/app/actions/[id]/page.tsx
+++ b/frontend/app/actions/[id]/page.tsx
@@ -24,6 +24,13 @@ interface Preview {
   impact: any
   risks: string[]
   recommendations: string[]
+  // Snapshot-specific fields
+  snapshot_age_days?: number | null
+  snapshot_size_gb?: number | null
+  linked_ami_id?: string | null
+  linked_ami_ids?: string[]
+  blocked_reason?: string | null
+  would_delete?: boolean
 }
 
 export default function ActionPage() {
@@ -35,6 +42,7 @@ export default function ActionPage() {
   const [preview, setPreview] = useState<Preview | null>(null)
   const [loading, setLoading] = useState(true)
   const [approving, setApproving] = useState(false)
+  const [snapshotConfirmed, setSnapshotConfirmed] = useState(false)
 
   useEffect(() => {
     const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
@@ -172,6 +180,38 @@ export default function ActionPage() {
           </dl>
         </div>
 
+        {/* Snapshot Metadata Card */}
+        {detection.resource_type === 'ebs_snapshot' && preview && (
+          <div className="bg-orange-50 border border-orange-200 rounded-lg shadow p-6 mb-6">
+            <h2 className="text-lg font-semibold text-orange-900 mb-4">📸 Snapshot Details</h2>
+            <dl className="grid grid-cols-3 gap-4">
+              <div>
+                <dt className="text-sm font-medium text-orange-700">Age</dt>
+                <dd className="mt-1 text-sm text-orange-900 font-semibold">
+                  {preview.snapshot_age_days != null ? `${preview.snapshot_age_days} days` : 'Unknown'}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-sm font-medium text-orange-700">Size</dt>
+                <dd className="mt-1 text-sm text-orange-900 font-semibold">
+                  {preview.snapshot_size_gb != null ? `${preview.snapshot_size_gb} GB` : 'Unknown'}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-sm font-medium text-orange-700">Linked AMI</dt>
+                <dd className="mt-1 text-sm text-orange-900 font-semibold">
+                  {preview.linked_ami_id || 'None'}
+                </dd>
+              </div>
+            </dl>
+            {preview.blocked_reason && (
+              <div className="mt-4 p-3 bg-red-100 border border-red-300 rounded-md">
+                <p className="text-sm text-red-800 font-medium">⚠️ Blocked: {preview.blocked_reason}</p>
+              </div>
+            )}
+          </div>
+        )}
+
         {/* Preview */}
         {preview && (
           <div className="bg-white rounded-lg shadow p-6 mb-6">
@@ -214,6 +254,31 @@ export default function ActionPage() {
         {detection.status === 'pending' && (
           <div className="bg-white rounded-lg shadow p-6">
             <h2 className="text-lg font-semibold text-gray-900 mb-4">Actions</h2>
+
+            {/* Permanent-action warning for snapshot deletions */}
+            {detection.resource_type === 'ebs_snapshot' && (
+              <div className="mb-5 p-4 bg-red-50 border-2 border-red-400 rounded-lg">
+                <p className="text-red-800 font-bold text-sm mb-1">
+                  ⛔ WARNING: Permanent Action
+                </p>
+                <p className="text-red-700 text-sm">
+                  Deleting a snapshot is <strong>permanent and cannot be undone</strong>.
+                  Once deleted, the snapshot data cannot be recovered.
+                </p>
+                <label className="flex items-center gap-2 mt-3 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={snapshotConfirmed}
+                    onChange={(e) => setSnapshotConfirmed(e.target.checked)}
+                    className="h-4 w-4 text-red-600 border-gray-300 rounded"
+                  />
+                  <span className="text-sm text-red-800 font-medium">
+                    I understand this action is permanent and cannot be undone
+                  </span>
+                </label>
+              </div>
+            )}
+
             <div className="flex gap-4">
               <button
                 onClick={() => handleApprove(true)}
@@ -224,8 +289,16 @@ export default function ActionPage() {
               </button>
               <button
                 onClick={() => handleApprove(false)}
-                disabled={approving}
-                className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 disabled:opacity-50"
+                disabled={
+                  approving ||
+                  (detection.resource_type === 'ebs_snapshot' && !snapshotConfirmed)
+                }
+                className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                title={
+                  detection.resource_type === 'ebs_snapshot' && !snapshotConfirmed
+                    ? 'Check the confirmation box above before approving'
+                    : undefined
+                }
               >
                 {approving ? 'Processing...' : 'Approve & Execute'}
               </button>

--- a/frontend/app/actions/page.tsx
+++ b/frontend/app/actions/page.tsx
@@ -22,6 +22,7 @@ export default function ActionsPage() {
   const [total, setTotal] = useState(0)
   const [loading, setLoading] = useState(true)
   const [statusFilter, setStatusFilter] = useState('all')
+  const [resourceTypeFilter, setResourceTypeFilter] = useState('all')
   const [selectedIds, setSelectedIds] = useState<number[]>([])
   const [batchProcessing, setBatchProcessing] = useState(false)
   const [stats, setStats] = useState({
@@ -32,13 +33,16 @@ export default function ActionsPage() {
     failed: 0,
   })
 
-  const fetchDetections = async (status?: string) => {
+  const fetchDetections = async (status?: string, resourceType?: string) => {
     setLoading(true)
     const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
     try {
       const params = new URLSearchParams()
       if (status && status !== 'all') {
         params.append('status', status)
+      }
+      if (resourceType && resourceType !== 'all') {
+        params.append('resource_type', resourceType)
       }
 
       const response = await fetch(
@@ -75,8 +79,8 @@ export default function ActionsPage() {
   }
 
   useEffect(() => {
-    fetchDetections(statusFilter)
-  }, [statusFilter])
+    fetchDetections(statusFilter, resourceTypeFilter)
+  }, [statusFilter, resourceTypeFilter])
 
   const handleApprove = async (detectionId: number) => {
     if (!confirm('Approve this action? This will execute the action on AWS.')) {
@@ -326,7 +330,7 @@ export default function ActionsPage() {
           </div>
         </div>
 
-        {/* Filter */}
+        {/* Filters */}
         <div className="bg-white rounded-lg shadow p-6 mb-6">
           <h2 className="text-lg font-semibold text-gray-900 mb-4">Filter by Status</h2>
           <div className="flex flex-wrap gap-2">
@@ -343,6 +347,30 @@ export default function ActionsPage() {
                   }`}
               >
                 {status.charAt(0).toUpperCase() + status.slice(1)}
+              </button>
+            ))}
+          </div>
+
+          <h2 className="text-lg font-semibold text-gray-900 mt-5 mb-3">Filter by Resource Type</h2>
+          <div className="flex flex-wrap gap-2">
+            {[
+              { value: 'all', label: 'All Types' },
+              { value: 'ec2_instance', label: '🖥️ EC2 Instance' },
+              { value: 'ebs_volume', label: '💾 EBS Volume' },
+              { value: 'ebs_snapshot', label: '📸 EBS Snapshot' },
+            ].map(({ value, label }) => (
+              <button
+                key={value}
+                onClick={() => {
+                  setResourceTypeFilter(value)
+                  setSelectedIds([])
+                }}
+                className={`px-4 py-2 rounded-md font-medium transition ${resourceTypeFilter === value
+                  ? 'bg-indigo-600 text-white'
+                  : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+                  }`}
+              >
+                {label}
               </button>
             ))}
           </div>


### PR DESCRIPTION
Implements CWH-39: Add snapshot deletion actions to Action Center

## Changes

- New `SnapshotClient` wrapper for boto3 snapshot calls
- Live safety check before snapshot deletion (blocks if AMI-linked)
- Snapshot metadata enrichment in preview (age, size, linked AMI)
- resource_type filter on action list endpoint
- Frontend resource-type filter dropdown
- Frontend snapshot metadata card and permanent-action warning
- Unit tests for all new components

Closes #32

Generated with [Claude Code](https://claude.ai/code)